### PR TITLE
replace code to a minimun of two slashes per line

### DIFF
--- a/preprocessor.ts
+++ b/preprocessor.ts
@@ -129,8 +129,7 @@ function blank_code(lines: string[], start: number, end: number) {
          lines[t] = ("/" as any).repeat(lines[t].length+1)+'\r';
       }
       else {
-         lines[t] = ("/" as any).repeat(lines[t].length);
+         lines[t] = ("/" as any).repeat(Math.max(lines[t].length, 2));
       }
    }
 }
-


### PR DESCRIPTION
This PR prevents an syntax error when replace code of a line with just one character
```javascript
/// #if true
function foo(){
  // ...
}
/// #endif
```

Will throw:
```
Module build failed: SyntaxError: Unterminated regular expression (4:1)
> 4 | /
    |  ^
```