### PR TITLE
Include file path in verbose logs

### DIFF
--- a/ifdef-loader.ts
+++ b/ifdef-loader.ts
@@ -1,5 +1,6 @@
 import * as loaderUtils from 'loader-utils';
 import { parse } from './preprocessor';
+import * as path from 'path';
 
 export = function(source: string, map) {
    this.cacheable && this.cacheable();
@@ -15,6 +16,11 @@ export = function(source: string, map) {
       delete data[verboseFlag];
    }
 
+   let filePath: string | undefined = undefined;
+   if(verbose) {
+      filePath = path.relative(this.rootContext, this.resourcePath);
+   }
+
    const tripleSlashFlag = "ifdef-triple-slash";
    const tripleSlash = data[tripleSlashFlag];
    if(tripleSlash !== undefined) {
@@ -22,7 +28,7 @@ export = function(source: string, map) {
    }
 
    try {
-      source = parse(source, data, verbose, tripleSlash);
+      source = parse(source, data, verbose, tripleSlash, filePath);
       this.callback(null, source, map);
    } catch(err) {
       const errorMessage = `ifdef-loader error: ${err}`;

--- a/preprocessor.ts
+++ b/preprocessor.ts
@@ -37,7 +37,7 @@ enum IfType { If, Elif }
 
 let useTripleSlash: boolean|undefined;
 
-export function parse(source: string, defs: OptionObject, verbose?: boolean, tripleSlash?: boolean): string {
+export function parse(source: string, defs: OptionObject, verbose?: boolean, tripleSlash?: boolean, filePath?: string): string {
    if(tripleSlash === undefined) tripleSlash = true;
    useTripleSlash = tripleSlash;
 
@@ -48,7 +48,7 @@ export function parse(source: string, defs: OptionObject, verbose?: boolean, tri
 
    var ifBlocks = find_if_blocks(lines);
    for(let ifBlock of ifBlocks) {
-      apply_if(lines, ifBlock, defs, verbose);
+      apply_if(lines, ifBlock, defs, verbose, filePath);
    }
 
    return lines.join('\n');
@@ -147,7 +147,7 @@ function match_else(line: string): boolean {
 }
 
 /** Includes and excludes relevant lines based on evaluation of the provided IfBlock */
-function apply_if(lines: string[], ifBlock: IfBlock, defs: OptionObject, verbose: boolean = false) {
+function apply_if(lines: string[], ifBlock: IfBlock, defs: OptionObject, verbose: boolean = false, filePath?: string) {
    let includeRange: [number, number]|null = null;
 
    const ifCond = parse_if(lines[ifBlock.startIx]);
@@ -155,7 +155,7 @@ function apply_if(lines: string[], ifBlock: IfBlock, defs: OptionObject, verbose
 
    const log = (condition: string, outcome: boolean) => {
       if(verbose) {
-         console.log(`#if block lines [${ifBlock.startIx + 1}-${ifBlock.endIx + 1}]: Condition '${condition}' is ${outcome ? 'TRUE' : 'FALSE'}. ${includeRange != null ? `Including lines [${includeRange[0] + 1}-${includeRange[1] + 1}].` : 'Excluding everything.'}`);
+         console.log(`#if block lines [${ifBlock.startIx + 1}-${ifBlock.endIx + 1}]: Condition '${condition}' is ${outcome ? 'TRUE' : 'FALSE'}. ${includeRange != null ? `Including lines [${includeRange[0] + 1}-${includeRange[1] + 1}].` : 'Excluding everything.'} ${filePath}`);
       }
    };
 


### PR DESCRIPTION
While debugging an issue with blocks not being found correctly (ended up being encoding related, not plugin related), I found the verbose logs weren't very helpful because I didn't know which file they related to.

This PR appends the relative file path (from webpack context root) to the end of each log line.

Before:
```
#if block lines [76-78]: Condition 'DEBUG' is FALSE. Excluding everything.
#if block lines [84-86]: Condition 'DEBUG' is FALSE. Excluding everything.
#if block lines [144-150]: Condition 'DEBUG' is FALSE. Excluding everything.
#if block lines [316-326]: Condition 'DEBUG' is FALSE. Excluding everything.
```

After:
```
#if block lines [76-78]: Condition 'DEBUG' is FALSE. Excluding everything. relative\path\to\file\being\loaded\Foo.ts
#if block lines [84-86]: Condition 'DEBUG' is FALSE. Excluding everything. relative\path\to\file\being\loaded\Foo.ts
#if block lines [144-150]: Condition 'DEBUG' is FALSE. Excluding everything. relative\path\to\file\being\loaded\Bar.ts
#if block lines [316-326]: Condition 'DEBUG' is FALSE. Excluding everything. relative\path\to\file\being\loaded\Bar.ts
```
